### PR TITLE
Updated the image name in the deployment.yaml

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: registry.edwardnafornita.com/schedule-bot:latest
+          image: registry.edwardnafornita.com/discord-bot:latest
           env:
             - name: DISCORD_TOKEN
               valueFrom:


### PR DESCRIPTION
**Description**

- Referenced the wrong docker image name in the deployment causing Argo to fail